### PR TITLE
Fix iCal timed events showing in wrong timezone

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -19,8 +19,8 @@ class CalendarsController < ApplicationController
           e.dtstart = Icalendar::Values::Date.new(event.start_date.to_date)
           e.dtend = Icalendar::Values::Date.new((event.end_date || event.start_date).to_date + 1.day)
         else
-          e.dtstart = Icalendar::Values::DateTime.new(event.start_date.utc)
-          e.dtend = Icalendar::Values::DateTime.new((event.end_date || event.start_date + 1.hour).utc)
+          e.dtstart = Icalendar::Values::DateTime.new(event.start_date.utc, "tzid" => "UTC")
+          e.dtend = Icalendar::Values::DateTime.new((event.end_date || event.start_date + 1.hour).utc, "tzid" => "UTC")
         end
       end
     end

--- a/spec/requests/calendars_spec.rb
+++ b/spec/requests/calendars_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe "Calendars", type: :request do
       expect(response.body).to include("UID:event-#{event.id}@")
     end
 
+    it "outputs timed event datetimes as UTC (with Z suffix)" do
+      create(:event, title: "Zeitgestempeltes Event", start_date: 1.week.from_now, all_day: false)
+
+      get calendar_path
+
+      expect(response.body).to match(/DTSTART:\d{8}T\d{6}Z/)
+      expect(response.body).to match(/DTEND:\d{8}T\d{6}Z/)
+    end
+
     it "excludes non-visible events" do
       create(:event, title: "Hidden Event", start_date: 1.week.from_now, visible: false)
 


### PR DESCRIPTION
## Why

Timed events exported via the `.ics` calendar feed appear 1–2 hours earlier than their actual scheduled time. Calendar apps (Apple Calendar, Google Calendar, etc.) were displaying the wrong time.

## Approach

The `icalendar` gem only appends a `Z` UTC suffix to datetime values when `"tzid" => "UTC"` is explicitly passed as a parameter. Without it, the gem outputs a *floating* datetime (no timezone indicator), which calendar apps interpret as local time — but the value was already converted to UTC, causing the offset error.

The minimal fix is to pass `"tzid" => "UTC"` alongside the UTC time values.

## How it works

`Icalendar::Values::DateTime#value_ical` checks an internal `tz_utc` flag, which is only set to `true` when `params['tzid'] == 'UTC'`. Without this flag the output is `DTSTART:20260415T160000` (floating), with it the output is `DTSTART:20260415T160000Z` (UTC). Calendar clients then correctly convert `160000Z` → `18:00 CEST`.

A new spec asserts the `Z` suffix is present on both `DTSTART` and `DTEND` for timed events.